### PR TITLE
fix: Resolve TypeError for MPS version parsing

### DIFF
--- a/tests/core/test_envs.py
+++ b/tests/core/test_envs.py
@@ -20,6 +20,9 @@ class TestEnvs(unittest.TestCase):
         self.assertEqual(device.type, 'mps')
         device_name = envs.get_device_name()
         self.assertEqual(device_name, 'mps')
+        # test that getting CUDA_VERSION does not raise an error
+        cuda_version = envs.CUDA_VERSION
+        self.assertIsNotNone(cuda_version)
 
     @patch('torch.cuda.is_available', return_value=False)
     @patch('xfuser.envs._is_mps', return_value=False)

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -122,7 +122,7 @@ def get_torch_distributed_backend() -> str:
 variables: Dict[str, Callable[[], Any]] = {
     # ================== Other Vars ==================
     # used in version checking
-    "CUDA_VERSION": lambda: version.parse(get_device_version()),
+    "CUDA_VERSION": lambda: version.parse(get_device_version() or "0.0"),
     "TORCH_VERSION": lambda: version.parse(
         version.parse(torch.__version__).base_version
     ),


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when running the library on an MPS device. The error was caused by `get_device_version()` returning `None` for MPS, which `packaging.version.parse()` cannot handle.

The fix modifies the lambda function for `CUDA_VERSION` in `xfuser/envs.py` to provide a default version string ("0.0") when `get_device_version()` returns `None`.

A new test case has also been added to `tests/core/test_envs.py` to ensure that accessing `envs.CUDA_VERSION` in a mocked MPS environment does not raise an error, preventing future regressions.